### PR TITLE
notification

### DIFF
--- a/cdk/stacks/pipeline_stack.py
+++ b/cdk/stacks/pipeline_stack.py
@@ -54,7 +54,7 @@ class CodePipelineStack(Stack):
         )
         chatbot.add_notification_topic(topic)
 
-        # Tests, test, test, test, test, test, test
+        # Tests, test, test, test, test, test, test, test
         # Notification rule
         pipeline_notification_rule = pipeline.pipeline.on_event(
             id="PipelineNotification",


### PR DESCRIPTION
- subscribe chatbot to topic
- test
- try personal slack channel
- use method to add notificatin topic
- remove input transformer because of eventbridge restriction: https://repost.aws/knowledge-center/sns-aws-chatbot-message-troubleshooting
- test with new setup
- integrate slack via email
- test
- test
