### PR TITLE
notification

### DIFF
--- a/cdk/stacks/pipeline_stack.py
+++ b/cdk/stacks/pipeline_stack.py
@@ -75,13 +75,13 @@ class CodePipelineStack(Stack):
         pipeline_notification_rule.add_target(
             aws_events_targets.SnsTopic(
                 topic,
-                message=aws_events.RuleTargetInput.from_object(
-                    {
-                        "ExecutionResult": aws_events.EventField.from_path(
-                            "$.detail.execution-result"
-                        )
-                    }
-                ),
+                # message=aws_events.RuleTargetInput.from_object(
+                #     {
+                #         "ExecutionResult": aws_events.EventField.from_path(
+                #             "$.detail.execution-result"
+                #         )
+                #     }
+                # ),
             )
         )
 


### PR DESCRIPTION
- subscribe chatbot to topic
- test
- try personal slack channel
- use method to add notificatin topic
- remove input transformer because of eventbridge restriction: https://repost.aws/knowledge-center/sns-aws-chatbot-message-troubleshooting
- test with new setup
- integrate slack via email
- test
- test
- pass chatbot to codestar notification rule
- resubscribe chatbot to sns topic
- test
- disable input transformer
