### PR TITLE
slack webhook lambda

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,7 +4,6 @@ import aws_cdk as cdk
 
 from cdk.stacks.pipeline_stack import CodePipelineStack
 
-
 app = cdk.App()
 CodePipelineStack(app, "CodePipelineStack")
 

--- a/cdk/assets/lambdas/hitcounter.py
+++ b/cdk/assets/lambdas/hitcounter.py
@@ -1,5 +1,7 @@
+from aws_cdk import RemovalPolicy
+from aws_cdk import aws_dynamodb as ddb
+from aws_cdk import aws_lambda as _lambda
 from constructs import Construct
-from aws_cdk import aws_lambda as _lambda, aws_dynamodb as ddb, RemovalPolicy
 
 
 class HitCounter(Construct):

--- a/cdk/assets/lambdas/pipeline_notification_construct.py
+++ b/cdk/assets/lambdas/pipeline_notification_construct.py
@@ -1,0 +1,19 @@
+from aws_cdk import aws_lambda
+from constructs import Construct
+
+
+class NotificationParser(Construct):
+    @property
+    def handler(self):
+        return self._handler
+
+    def __init__(self, scope: Construct, construct_id: str, **kwargs):
+        super().__init__(scope, construct_id, **kwargs)
+
+        self._handler = aws_lambda.Function(
+            self,
+            "NotificationParser",
+            runtime=aws_lambda.Runtime.PYTHON_3_10,
+            code=aws_lambda.Code.from_asset("lambda"),
+            handler="notification_parser.handler",
+        )

--- a/cdk/stacks/helloworld_stack.py
+++ b/cdk/stacks/helloworld_stack.py
@@ -1,17 +1,11 @@
-from constructs import Construct
-from aws_cdk import (
-    # Duration,
-    Stack,
-    CfnOutput,
-    # aws_iam as iam,
-    # aws_sqs as sqs,
-    # aws_sns as sns,
-    # aws_sns_subscriptions as subs,
-    aws_lambda as _lambda,  # '_' naming to avoid collision with builtin `lambda` name
-    aws_apigateway as apigw,
-)
-
+from aws_cdk import CfnOutput, Stack
+from aws_cdk import aws_apigateway as apigw
+from aws_cdk import \
+    aws_lambda as \
+    _lambda  # Duration,; aws_iam as iam,; aws_sqs as sqs,; aws_sns as sns,; aws_sns_subscriptions as subs,; '_' naming to avoid collision with builtin `lambda` name
 from cdk_dynamo_table_view import TableViewer
+from constructs import Construct
+
 from cdk.assets.lambdas.hitcounter import HitCounter
 
 

--- a/cdk/stacks/pipeline_stack.py
+++ b/cdk/stacks/pipeline_stack.py
@@ -1,10 +1,11 @@
-from aws_cdk import (Stack, aws_codestarnotifications, aws_events,
+from aws_cdk import (Stack, aws_codestarnotifications,
                      aws_events_targets, aws_sns, aws_sns_subscriptions,
                      pipelines)
+from aws_cdk.aws_lambda_event_sources import SnsEventSource
 from constructs import Construct
 
+from cdk.assets.lambdas.pipeline_notification_construct import NotificationParser
 from cdk.stages.pipeline_stage import CodePipelineStage
-
 
 class CodePipelineStack(Stack):
     def __init__(self, scope: Construct, id: str, **kwargs) -> None:
@@ -33,12 +34,17 @@ class CodePipelineStack(Stack):
 
         pipeline.build_pipeline()
 
-        # SNS notification
+        # SNS topic
         topic = aws_sns.Topic(self, "Topic", display_name="Test subscription topic")
         topic.add_subscription(
             aws_sns_subscriptions.EmailSubscription("anovoszath@diligent.com")
         )
         topic.add_subscription(aws_sns_subscriptions.EmailSubscription("pipeline-test-notific-aaaakaddfvgdfiomr5sejtgaka@diligent.slack.com"))
+        
+        # Lambda function
+        notification_parser = NotificationParser(self, "PipelineNotificationParser")
+        notification_parser.handler.add_event_source(SnsEventSource(topic))
+
 
         # Tests, test, test, test, test, test, test, test, test, test, test, test
         # Notification rule

--- a/cdk/stacks/pipeline_stack.py
+++ b/cdk/stacks/pipeline_stack.py
@@ -1,14 +1,8 @@
+from aws_cdk import (Stack, aws_codestarnotifications, aws_events,
+                     aws_events_targets, aws_sns, aws_sns_subscriptions,
+                     pipelines)
 from constructs import Construct
-from aws_cdk import (
-    Stack,
-    pipelines,
-    aws_chatbot,
-    aws_events,
-    aws_events_targets,
-    aws_sns,
-    aws_sns_subscriptions,
-    aws_codestarnotifications,
-)
+
 from cdk.stages.pipeline_stage import CodePipelineStage
 
 
@@ -45,15 +39,6 @@ class CodePipelineStack(Stack):
             aws_sns_subscriptions.EmailSubscription("anovoszath@diligent.com")
         )
         topic.add_subscription(aws_sns_subscriptions.EmailSubscription("pipeline-test-notific-aaaakaddfvgdfiomr5sejtgaka@diligent.slack.com"))
-        
-        chatbot = aws_chatbot.SlackChannelConfiguration(
-            self,
-            "DataHubInfraPipeline",
-            slack_channel_configuration_name="DhInfraPipelineStackNotifier",
-            slack_channel_id="C05EP6J1HS6", # "C05BTLSLYGJ" original
-            slack_workspace_id="T4S8MSGSX",
-        )
-        chatbot.add_notification_topic(topic)
 
         # Tests, test, test, test, test, test, test, test, test, test, test, test
         # Notification rule

--- a/cdk/stages/pipeline_stage.py
+++ b/cdk/stages/pipeline_stage.py
@@ -1,5 +1,6 @@
-from constructs import Construct
 from aws_cdk import Stage
+from constructs import Construct
+
 from cdk.stacks.helloworld_stack import HelloWorldStack
 
 

--- a/lambda/notification_parser.py
+++ b/lambda/notification_parser.py
@@ -1,0 +1,28 @@
+import json
+from urllib3 import PoolManager
+
+http = PoolManager()
+
+
+def handler(event, context):
+    print(f"request: {json.dumps(event)}")
+    url = "https://hooks.slack.com/services/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"
+    msg = {
+        "channel": "#pipeline-notification-test",
+        "username": "Pipeline Deploy Watcher Bot",
+        "text": event["Records"][0]["Sns"]["Message"],
+        "icon_emoji": ":space_invader:",
+    }
+
+    encoded_msg = json.dumps(msg).encode("utf-8")
+    resp = http.request("POST", url, body=encoded_msg)
+    print(
+        "After encoding:\n",
+        {
+            "message": event["Records"][0]["Sns"]["Message"],
+            "status_code": resp.status,
+            "response": resp.data,
+        },
+    )
+
+    return json.loads(encoded_msg)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 aws-cdk-lib==2.84.0
 constructs>=10.0.0,<11.0.0
 cdk-dynamo-table-view
+urllib3>=2.0.3

--- a/tests/unit/test_cdk_workshop.py
+++ b/tests/unit/test_cdk_workshop.py
@@ -1,7 +1,8 @@
-from aws_cdk import Stack, aws_lambda as _lambda, assertions
+import pytest
+from aws_cdk import Stack, assertions
+from aws_cdk import aws_lambda as _lambda
 
 from cdk.hitcounter import HitCounter
-import pytest
 
 
 def test_dynamodb_table_created():


### PR DESCRIPTION
- subscribe chatbot to topic
- test
- try personal slack channel
- use method to add notificatin topic
- remove input transformer because of eventbridge restriction: https://repost.aws/knowledge-center/sns-aws-chatbot-message-troubleshooting
- test with new setup
- integrate slack via email
- test
- test
- pass chatbot to codestar notification rule
- resubscribe chatbot to sns topic
- test
- disable input transformer
- test
- test
- test
- add topic to codestar notification rule
- test
- test
- isort
- remove chatbot
- notification parser lambda function
