### PR TITLE
slack webhook lambda

### DIFF
--- a/lambda/notification_parser.py
+++ b/lambda/notification_parser.py
@@ -6,7 +6,7 @@ http = PoolManager()
 
 def handler(event, context):
     print(f"request: {json.dumps(event)}")
-    url = "https://hooks.slack.com/services/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"
+    url = "https://hooks.slack.com/services/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"
     msg = {
         "channel": "#pipeline-notification-test",
         "username": "Pipeline Deploy Watcher Bot",
@@ -19,7 +19,7 @@ def handler(event, context):
     print(
         "After encoding:\n",
         {
-            "message": event["Records"][0]["Sns"]["Message"],
+            "message": encoded_msg,
             "status_code": resp.status,
             "response": resp.data,
         },


### PR DESCRIPTION
- subscribe chatbot to topic
- test
- try personal slack channel
- use method to add notificatin topic
- remove input transformer because of eventbridge restriction: https://repost.aws/knowledge-center/sns-aws-chatbot-message-troubleshooting
- test with new setup
- integrate slack via email
- test
- test
- pass chatbot to codestar notification rule
- resubscribe chatbot to sns topic
- test
- disable input transformer
- test
- test
- test
- add topic to codestar notification rule
- test
- test
- isort
- remove chatbot
- notification parser lambda function
- Update github connection arn
- change webhook token
