### PR TITLE
slack webhook lambda

### DIFF
--- a/lambda/notification_parser.py
+++ b/lambda/notification_parser.py
@@ -6,7 +6,7 @@ http = PoolManager()
 
 def handler(event, context):
     print(f"request: {json.dumps(event)}")
-    url = "https://hooks.slack.com/services/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"
+    url = "https://hooks.slack.com/services/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"
     msg = {
         "channel": "#pipeline-notification-test",
         "username": "Pipeline Deploy Watcher Bot",


### PR DESCRIPTION
- subscribe chatbot to topic
- test
- try personal slack channel
- use method to add notificatin topic
- remove input transformer because of eventbridge restriction: https://repost.aws/knowledge-center/sns-aws-chatbot-message-troubleshooting
- test with new setup
- integrate slack via email
- test
- test
- pass chatbot to codestar notification rule
- resubscribe chatbot to sns topic
- test
- disable input transformer
- test
- test
- test
- add topic to codestar notification rule
- test
- test
- isort
- remove chatbot
- notification parser lambda function
- Update github connection arn
- change webhook token
- test
- refresh slack webhook token
- Create webhook of new app
