### PR TITLE
slack webhook lambda

### DIFF
--- a/lambda/notification_parser.py
+++ b/lambda/notification_parser.py
@@ -1,12 +1,21 @@
 import json
 from urllib3 import PoolManager
 
+import boto3
+
 http = PoolManager()
+session = boto3.session.Session()
+client = session.client(service_name="secretsmanager", region_name="us-west-2")
 
 
 def handler(event, context):
     print(f"request: {json.dumps(event)}")
-    url = "https://hooks.slack.com/services/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"
+
+    get_secret_value_response = client.get_secret_value(
+        SecretID="TestSlackWebhookToken"
+    )
+    webhook_token = get_secret_value_response['SecretString']
+
     msg = {
         "channel": "#pipeline-notification-test",
         "username": "Pipeline Deploy Watcher Bot",
@@ -15,7 +24,7 @@ def handler(event, context):
     }
 
     encoded_msg = json.dumps(msg).encode("utf-8")
-    resp = http.request("POST", url, body=encoded_msg)
+    resp = http.request("POST", webhook_token, body=encoded_msg)
     print(
         "After encoding:\n",
         {


### PR DESCRIPTION
- subscribe chatbot to topic
- test
- try personal slack channel
- use method to add notificatin topic
- remove input transformer because of eventbridge restriction: https://repost.aws/knowledge-center/sns-aws-chatbot-message-troubleshooting
- test with new setup
- integrate slack via email
- test
- test
- pass chatbot to codestar notification rule
- resubscribe chatbot to sns topic
- test
- disable input transformer
- test
- test
- test
- add topic to codestar notification rule
- test
- test
- isort
- remove chatbot
- notification parser lambda function
- Update github connection arn
- change webhook token
- test
- refresh slack webhook token
- Create webhook of new app
- pull webhook token from secret manager
