### PR TITLE
slack webhook lambda

### DIFF
--- a/cdk/assets/lambdas/pipeline_notification_construct.py
+++ b/cdk/assets/lambdas/pipeline_notification_construct.py
@@ -26,7 +26,7 @@ class NotificationParser(Construct):
                     "secretsmanager:GetSecretValue",
                 ],
                 resources=[
-                    "arn:aws:lambda:us-west-2:681724587179:function:CodePipelineStack-PipelineNotificationParser891594-TA3zz3bbVkZW:*",
+                    "arn:aws:secretsmanager:us-west-2:681724587179:secret:TestSlackWebhookToken-BRXYiK:*",
                 ],
             )
         )


### PR DESCRIPTION
- pull webhook token from secret manager
- - add permission to get secret value - change secret arm
- test
- typo fix
- use correct arn in lambda access policy
