### PR TITLE
slack webhook lambda

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ venv.bak/
 # CDK Context & Staging files
 .cdk.staging/
 cdk.out/
+
+# Local environment
+.vscode

--- a/lambda/notification_parser.py
+++ b/lambda/notification_parser.py
@@ -14,25 +14,50 @@ def handler(event, context):
     get_secret_value_response = secretsmanager.get_secret_value(
         SecretId="arn:aws:secretsmanager:us-west-2:681724587179:secret:TestSlackWebhookToken-BRXYiK"
     )
-    
     webhook_token = json.loads(get_secret_value_response["SecretString"])["token"]
 
+    eventbridge = event["Records"][0]["Sns"]["Message"]["detail"]
+    commit_text = json.loads(
+        eventbridge["execution-result"]["external-execution-summary"]
+    )["CommitMessage"]
+    pr_info, commit_message = commit_text.split("\n\n")
+
     msg = {
-        "channel": "#pipeline-notification-test",
-        "username": "Pipeline Deploy Watcher Bot",
-        "text": event["Records"][0]["Sns"]["Message"],
-        "icon_emoji": ":space_invader:",
+        "text": "simple text",
+        "blocks": [
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f":hammer_and_wrench: *{eventbridge['state']} | {eventbridge['region']}*",
+                },
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"*Pipeline*: {eventbridge['pipeline']}",
+                },
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"<{eventbridge['execution-result']['external-execution-url']}|{pr_info}>",
+                },
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"*Message*: {commit_message}",
+                },
+            },
+            {"type": "divider"},
+        ],
     }
 
     encoded_msg = json.dumps(msg).encode("utf-8")
     resp = http.request("POST", webhook_token, body=encoded_msg)
-    print(
-        "After encoding:\n",
-        {
-            "message": encoded_msg,
-            "status_code": resp.status,
-            "response": resp.data,
-        },
-    )
 
     return json.loads(encoded_msg)


### PR DESCRIPTION
- pull webhook token from secret manager
- - add permission to get secret value - change secret arm
- test
- typo fix
- use correct arn in lambda access policy
- remove ending from token arm
- fix token access via json
- ignore vscode config
- format slack message
