### PR TITLE
test

### DIFF
--- a/cdk/stacks/pipeline_stack.py
+++ b/cdk/stacks/pipeline_stack.py
@@ -55,7 +55,7 @@ class CodePipelineStack(Stack):
         notification_parser = NotificationParser(self, "PipelineNotificationParser")
         notification_parser.handler.add_event_source(SnsEventSource(topic))
 
-        # Tests, test, test, test, test, test, test, test, test, test, test, test, test, test, test
+        # Tests, test, test, test, test, test, test, test, test, test, test, test, test, test, test, test
         # Notification rule
         pipeline_notification_rule = pipeline.pipeline.on_event(
             id="PipelineNotification",


### PR DESCRIPTION
- pull webhook token from secret manager
- - add permission to get secret value - change secret arm
- test
- typo fix
- use correct arn in lambda access policy
- remove ending from token arm
- fix token access via json
- ignore vscode config
- format slack message
- turn back notification rule test eventrule minor message formatting
- redeploy
- test
- try full sns message
- test
